### PR TITLE
Remove unused outdated zlib dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "aws-sdk": "^2.2.25",
     "q": "^1.4.1",
-    "request": "^2.67.0",
-    "zlib": "^1.0.5"
+    "request": "^2.67.0"
   }
 }


### PR DESCRIPTION
zlib has been part of node since at least 0.5.8.  Installing zlib with npm resolves to this https://github.com/kkaefer/DEPRECATED-node-zlib which doesn't build here.  require('zlib') loads zlib from node core anyways, not from the installed npm package.
